### PR TITLE
[Feature] Spring Security에서 기본 응답을 403에서 커스텀 응답 401로 변경

### DIFF
--- a/backend/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.example.demo.config;
 
+import com.example.demo.exception.CustomAuthenticationEntryPoint;
 import com.example.demo.jwt.JwtAccessTokenFilter;
 import com.example.demo.jwt.JwtRefreshTokenFilter;
-import com.example.demo.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +20,7 @@ public class SecurityConfig {
 
     private final JwtAccessTokenFilter jwtAccessTokenFilter;
     private final JwtRefreshTokenFilter jwtRefreshTokenFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -35,6 +36,9 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtAccessTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(jwtRefreshTokenFilter, JwtAccessTokenFilter.class)
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                )
                 .build();
     }
 

--- a/backend/src/main/java/com/example/demo/exception/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/example/demo/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.example.demo.exception;
+
+import com.example.demo.common.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.UNAUTHORIZED.getCode(), "액세스 할 권한이 없습니다");
+
+        response.setStatus(ErrorCode.UNAUTHORIZED.getHttpStatusCode());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
AuthenticationEntryPoint을 CustomAuthenticationEntryPoint으로 재구성하여 보호된 API 요청 시
accessToken이 없거나 잘못 되었거나, 갱신에 실패하여 권한이 부족할 때 
401 UNAUTHORIZED와 함께 "액세스 할 권한이 없습니다" 라는 메세지의 ErrorResponse를 반환하도록 수정하였습니다.