### PR TITLE
feat: 질문 목록 로드 API 기준 수정

### DIFF
--- a/backend/src/main/java/yeoun/question/domain/repository/QuestionRepository.java
+++ b/backend/src/main/java/yeoun/question/domain/repository/QuestionRepository.java
@@ -1,6 +1,10 @@
 package yeoun.question.domain.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import yeoun.question.domain.QuestionEntity;
+
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,8 +18,35 @@ public interface QuestionRepository extends JpaRepository<QuestionEntity, Long> 
     @Query("select q from QuestionEntity q left join fetch q.user where q.id = :id")
     Optional<QuestionEntity> findQuestionById(@Param("id") long id);
 
-    @Query("SELECT q FROM QuestionEntity q LEFT JOIN q.comments c GROUP BY q ORDER BY COUNT(c) DESC")
-    List<QuestionEntity> findAllOrderByCommentsCountDesc();
+    @Query("""
+            SELECT q FROM QuestionEntity q
+            LEFT JOIN q.comments c
+              ON c.createdDateTime BETWEEN :start AND :end
+            WHERE q.isFixed = false
+            GROUP BY q
+            ORDER BY COUNT(c) DESC, q.createdDateTime ASC
+        """)
+    Slice<QuestionEntity> findAllOrderByCommentsCount(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT q FROM QuestionEntity q
+            LEFT JOIN q.comments c
+              ON c.createdDateTime BETWEEN :start AND :end
+            WHERE q.isFixed = false
+            AND q.category.name = :category
+            GROUP BY q
+            ORDER BY COUNT(c) DESC, q.createdDateTime ASC
+            """)
+    Slice<QuestionEntity> findAllByCategoryAndTodayComments(
+            @Param("category") String category,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable
+    );
 
     @Query("SELECT q FROM QuestionEntity q LEFT JOIN FETCH q.comments left join fetch q.user WHERE q.id = :questionId")
     Optional<QuestionEntity> findQuestionWithCommentById(@Param("questionId") Long questionId);

--- a/backend/src/main/java/yeoun/question/service/QuestionService.java
+++ b/backend/src/main/java/yeoun/question/service/QuestionService.java
@@ -1,6 +1,11 @@
 package yeoun.question.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import yeoun.question.dto.request.AddQuestionRequest;
 import yeoun.question.domain.CategoryEntity;
 import yeoun.question.domain.QuestionEntity;
@@ -84,8 +89,14 @@ public class QuestionService {
         questionRepository.delete(question);
     }
 
-    public List<QuestionEntity> getAllQuestions() {
-        return questionRepository.findAllOrderByCommentsCountDesc();
+    public Slice<QuestionEntity> getAllQuestions(String category, Pageable pageable) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        if (category == null || category.isBlank()) {
+            return questionRepository.findAllOrderByCommentsCount(startOfDay, endOfDay, pageable);
+        }
+        return questionRepository.findAllByCategoryAndTodayComments(category, startOfDay, endOfDay, pageable);
     }
 
     public QuestionEntity getQuestionWithCommentById(Long id) {


### PR DESCRIPTION
프론트 분들은 아래 URL에서 API 규격 확인 (코드 리뷰 안하셔도 됩니다)
https://www.notion.so/1b1f0c6626cc806ab39cc593170ad65c?pvs=4

* 사용자들이 질문하기_질문 작성 페이지에서 작성한 질문만 조회
* 카테고리별 필터링 조회
* 당일 기준 댓글 많은 순으로 정렬, 여러개일 경우 먼저 작성된 질문이 먼저
* 10개씩 페이징 조회