### PR TITLE
[Feat] 로그인 & 인증

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ dist-ssr
 
 
 # mkcert pemkey
-localhost-key.pem
+localhost.key.pem
 localhost.pem
 
 backend/gradlew.bat

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,15 +1,43 @@
 import { useNavigate } from 'react-router-dom';
+
 import BackGroundCubeImage from '../assets/background-cube.svg?react';
 
+import useAuthStore from '../store/useAuthStore';
+
+import checkAuth from '../services/api/auth/checkAuth';
+
 const HomePage = () => {
+  const { setUserType, userType } = useAuthStore();
+
   const navigate = useNavigate();
-  const handleClick = () => {
-    navigate('/login');
+
+  const handleClick = async () => {
+    // 비회원
+    if (userType === 'Guest') {
+      return navigate('/today-question');
+    }
+
+    // 회원
+    if (userType === 'User') {
+      try {
+        await checkAuth();
+        setUserType('User');
+        return navigate('/today-question');
+      } catch {
+        setUserType(null);
+        return navigate('/login');
+      }
+    }
+
+    // 로그인하지 않았을 때
+    if (!userType) {
+      return navigate('/login');
+    }
   };
 
   return (
     <main className="relative flex min-h-[100svh] flex-col justify-between pt-8 pb-5">
-      <div className="relative space-y-6 px-6 after:absolute after:top-[calc(100%-93px)] after:left-0 after:h-[1px] after:w-[40%] after:bg-white/70 after:content-['']">
+      <div className="relative space-y-6 px-6 after:absolute after:top-[calc(100%-67px)] after:left-0 after:h-[1px] after:w-[40%] after:bg-white/70 after:content-['']">
         <p className="text-gradient text-2xl/9">
           하루의 끝,
           <br />
@@ -17,14 +45,10 @@ const HomePage = () => {
           <br />
           당신만의 여운을 남기세요
         </p>
-        <p className="font-desc text-sm">
-          매일 주어지는 질문에 답하고
+        <p className="font-desc text-sm/loose">
+          매일 답하고 기록을 쌓아보세요.
           <br />
-          나만의 기록을 쌓아보세요
-          <br />
-          다른 사람에게 의미있는 질문을 던지고
-          <br />
-          그들의 답변을 들어보세요
+          질문을 남기고 답변을 받아보세요.
         </p>
       </div>
 

--- a/frontend/src/pages/TodayQuestion/TodayQuestionLayout.tsx
+++ b/frontend/src/pages/TodayQuestion/TodayQuestionLayout.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 
-import { Outlet } from 'react-router-dom';
+import { Outlet, redirect } from 'react-router-dom';
 import { queryClient } from '../../utils/queryClient';
 import { getTodayQuestion } from '../../services/api/question/todayQuestion';
 import { TodayQuestion } from '../../type/question';
@@ -16,10 +16,19 @@ const TodayQuestionLayout = () => {
 
 export default TodayQuestionLayout;
 
-export const loader = async (): Promise<TodayQuestion> => {
+export const loader = async (): Promise<TodayQuestion | Response> => {
+  // authStorage가 비어있다면 홈으로 redirect
+  const authStorage = localStorage.getItem('auth-storage');
+
+  if (!authStorage) {
+    return redirect('/');
+  }
+
+  const { state } = JSON.parse(authStorage);
+
   const todayQuestion = await queryClient.fetchQuery({
     queryKey: ['today-question'],
-    queryFn: async () => await getTodayQuestion(),
+    queryFn: async () => await getTodayQuestion(state.userType),
   });
 
   return todayQuestion;

--- a/frontend/src/pages/login/LoginFallback.tsx
+++ b/frontend/src/pages/login/LoginFallback.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import useAuthStore from '../../store/useAuthStore';
+
+const LoginFallback = () => {
+  const { login, setUserType } = useAuthStore();
+  const { identifier } = useParams();
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get('code');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!identifier || !code) {
+      navigate('/');
+      return;
+    }
+    login(identifier, code)
+      .then(() => {
+        setUserType('User');
+        return navigate('/today-question');
+      })
+      .catch((error) => console.log(error));
+  }, [code, identifier, login, navigate, setUserType]);
+
+  return null;
+};
+
+export default LoginFallback;

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,7 +1,25 @@
-import { Link } from 'react-router-dom';
-import Circle from '../components/circle/Circle';
+import { Link, useNavigate } from 'react-router-dom';
+import Circle from '../../components/circle/Circle';
+import useAuthStore from '../../store/useAuthStore';
+import { useEffect } from 'react';
 
 const LoginPage = () => {
+  const { setUserType, userType } = useAuthStore();
+  const navigate = useNavigate();
+
+  // 비회원 로그인
+  const handleGuestLogin = () => {
+    setUserType('Guest');
+    navigate('/today-question');
+  };
+
+  useEffect(() => {
+    // 로그인 상태 일 때 리다이렉트
+    if (userType === 'User') {
+      navigate(-1);
+      return;
+    }
+  }, []);
   return (
     <main className="flex h-[100svh] flex-col items-center justify-between px-6 pt-10 pb-5">
       <div className="">
@@ -9,7 +27,7 @@ const LoginPage = () => {
           <Circle size={150} animate />
         </div>
         <p className="text-gradient text-center">
-          하루 한마디, 내 안에 스며드는
+          질문 하나, 마음속에 남는
           <span className="text-blur-pink pl-0.5 text-white"> 여운</span>
         </p>
       </div>
@@ -17,12 +35,12 @@ const LoginPage = () => {
       {/* Login Btn */}
       <ul className="font-desc flex w-full flex-col gap-4 text-center text-sm">
         <li>
-          <Link
-            to={'/today-question'}
-            className="block w-full rounded-xl border bg-transparent py-4.5"
+          <button
+            onClick={handleGuestLogin}
+            className="block w-full cursor-pointer rounded-xl border bg-transparent py-4.5"
           >
             로그인 없이 이용하기
-          </Link>
+          </button>
         </li>
         <li>
           <Link

--- a/frontend/src/routes/PrivateRoute.tsx
+++ b/frontend/src/routes/PrivateRoute.tsx
@@ -1,0 +1,13 @@
+import useAuthStore from '../store/useAuthStore';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const PrivateRoute = () => {
+  const { userType } = useAuthStore();
+  if (userType !== 'User') {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default PrivateRoute;

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -2,22 +2,28 @@ import { createBrowserRouter } from 'react-router-dom';
 
 import App from '../App.tsx';
 
+// 프라이빗 라우트
+import PrivateRoute from './PrivateRoute.tsx';
+
 import HomePage from '../pages/HomePage.tsx';
-import LoginPage from '../pages/LoginPage.tsx';
 import QuestionPage from '../pages/QuestionPage.tsx';
 import SettingPage from '../pages/SettingPage.tsx';
 import MyActivityPage from '../pages/MyActivityPage.tsx';
 
+//로그인
+import LoginPage from '../pages/login/LoginPage.tsx';
+import LoginFallback from '../pages/login/LoginFallback.tsx';
+
 // 오늘의 질문
-import TodayQuestionPage from '../pages/TodayQuestion/TodayQuestionPage.tsx';
+import TodayQuestionPage from '../pages/todayQuestion/TodayQuestionPage.tsx';
 import TodayQuestionCommentPage, {
   action as TodayQuestionAction,
-} from '../pages/TodayQuestion/TodayQuestionCommentPage.tsx';
+} from '../pages/todayQuestion/TodayQuestionCommentPage.tsx';
 import TodayQuestionLayout, {
   loader as TodayQestionLoader,
-} from '../pages/TodayQuestion/TodayQuestionLayout.tsx';
-import MyTodayAnswersPage from '../pages/TodayQuestion/MyTodayAnswersPage.tsx';
-import MyTodayAnswerPage from '../pages/TodayQuestion/MyTodayAnswerPage.tsx';
+} from '../pages/todayQuestion/TodayQuestionLayout.tsx';
+import MyTodayAnswersPage from '../pages/todayQuestion/MyTodayAnswersPage.tsx';
+import MyTodayAnswerPage from '../pages/todayQuestion/MyTodayAnswerPage.tsx';
 
 const router = createBrowserRouter([
   {
@@ -25,7 +31,14 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       { index: true, element: <HomePage /> },
-      { path: '/login', element: <LoginPage /> },
+      {
+        path: '/login',
+        element: <LoginPage />,
+      },
+      {
+        path: '/login/:identifier',
+        element: <LoginFallback />,
+      },
       {
         path: '/today-question',
         element: <TodayQuestionLayout />,
@@ -52,9 +65,14 @@ const router = createBrowserRouter([
           },
         ],
       },
-      { path: '/question', element: <QuestionPage /> },
-      { path: '/setting', element: <SettingPage /> },
-      { path: '/my-activity', element: <MyActivityPage /> },
+      {
+        element: <PrivateRoute />,
+        children: [
+          { path: '/question', element: <QuestionPage /> },
+          { path: '/setting', element: <SettingPage /> },
+          { path: '/my-activity', element: <MyActivityPage /> },
+        ],
+      },
     ],
   },
 ]);

--- a/frontend/src/services/api/auth/checkAuth.ts
+++ b/frontend/src/services/api/auth/checkAuth.ts
@@ -1,0 +1,8 @@
+import client from '../client';
+
+const checkAuth = async () => {
+  const response = await client.post('/public/auth/me');
+  return response;
+};
+
+export default checkAuth;

--- a/frontend/src/services/api/auth/fetchToken.ts
+++ b/frontend/src/services/api/auth/fetchToken.ts
@@ -1,0 +1,9 @@
+import client from '../client';
+
+const fetchToken = async (identifier: string, code: string) => {
+  const response = await client.get(`/public/auth/login/${identifier}?code=${code}`);
+
+  return response;
+};
+
+export default fetchToken;

--- a/frontend/src/services/api/question/todayQuestion.ts
+++ b/frontend/src/services/api/question/todayQuestion.ts
@@ -1,17 +1,27 @@
-import { TodayQuestion } from '../../../type/question';
-import Response from '../../../type/response';
 import client from '../client';
 
-const todayQuestionUrl = '/public/question/today';
+import { TodayQuestion } from '../../../type/question';
+import UserType from '../../../type/auth/UserType';
+import Response from '../../../type/response';
 
-export const getTodayQuestion = async (): Promise<TodayQuestion> => {
-  const response = await client.get<Promise<Response<TodayQuestion>>>(todayQuestionUrl);
+const getTodayQuestionUrl = (type: UserType) => {
+  if (type === 'User') {
+    return '/api/question/today';
+  } else {
+    return '/public/question/today';
+  }
+};
+
+export const getTodayQuestion = async (userType: UserType): Promise<TodayQuestion> => {
+  const response = await client.get<Promise<Response<TodayQuestion>>>(
+    getTodayQuestionUrl(userType)
+  );
 
   return (await response.data).data;
 };
 
-export const addTodayQuestionComment = async (content: string) => {
-  const response = await client.post(todayQuestionUrl, { content });
+export const addTodayQuestionComment = async (userType: UserType, content: string) => {
+  const response = await client.post(getTodayQuestionUrl(userType), { content });
 
   return response;
 };

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,20 +1,24 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+
+import UserType from '../type/auth/UserType';
+
 import fetchToken from '../services/api/auth/fetchToken';
 
 interface AuthState {
-  isLoggedIn: boolean;
+  userType: UserType;
   login: (identifier: string, code: string) => Promise<void>;
+  setUserType: (type: UserType) => void;
 }
 
 const useAuthStore = create(
-  persist<AuthState>(
+  persist<AuthState>( // zustand 미들웨어
     (set) => ({
-      isLoggedIn: false,
+      userType: null,
       login: async (identifier, code) => {
         await fetchToken(identifier, code);
-        set((state) => ({ ...state, isLoggedIn: true }));
       },
+      setUserType: (type) => set((state) => ({ ...state, userType: type })),
     }),
     {
       name: 'auth-storage',

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import fetchToken from '../services/api/auth/fetchToken';
+
+interface AuthState {
+  isLoggedIn: boolean;
+  login: (identifier: string, code: string) => Promise<void>;
+}
+
+const useAuthStore = create(
+  persist<AuthState>(
+    (set) => ({
+      isLoggedIn: false,
+      login: async (identifier, code) => {
+        await fetchToken(identifier, code);
+        set((state) => ({ ...state, isLoggedIn: true }));
+      },
+    }),
+    {
+      name: 'auth-storage',
+    }
+  )
+);
+
+export default useAuthStore;

--- a/frontend/src/type/auth/UserType.d.ts
+++ b/frontend/src/type/auth/UserType.d.ts
@@ -1,0 +1,3 @@
+type UserType = 'User' | 'Guest' | null;
+
+export default UserType;


### PR DESCRIPTION
> ## PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
>### 로그인 기능 구현 

소셜로그인 부분을 프론트에서 처리하기로 결정해서, 로그인 후에 **백엔드로 토큰 요청을 보내기 위해** LoginFallback 페이지를 만들었습니다 (921ce80fd3eee6533db85c14090f7ffbc02d90b)
해당 페이지에서 받고있는 **identity의 값으로는 'kakao' 'naver' 'google'** 이 있습니다 !

>### useAuthStore 정의 (8d66749fff593df012500a58a547e2cd80ffc848)

비회원/회원을 구별, 로그인 상태 유무를 확인하기 위해 useAuthStore 훅을 정의했습니다 !
> userType (f86adc946456037f6c5c60e85533dac1b9241dad)

현재 접속해있는 유저의 타입을 정의합니다.

**소셜 로그인 회원 = 'User'
비회원 = 'Guest'
비로그인 회원 = null**

> setUserType

userType을 변경하는 setState 함수

>### Private Route 설정 (fa26c95541945c7c57e71efc14147176180f9c65)
질문하기 페이지, 질문모음 페이지 등 **로그인하지 않았을 때 접근 할 수 없는 페이지**가 있어
로그인 하지 않았을 때 **해당 페이지의 접근을 막을 수 있는** Private Route를 추가했습니다 !

추후, 비로그인 유저가 접근 할 수 없는 페이지가 추가되었을 때 **해당 라우트의 children 으로 추가**하면 됩니다 !

>### 오늘의질문 API 비회원/회원 URL 판별 함수 추가 (2090ee6e270841c7cba6a0b23be49d204a7f5157)

오늘의 질문 API의 경우 비회원은 엔드포인트의 접두사가 **비회원 -> /public** & **회원 -> /api** 로 나누어져 있어서
해당 타입에 맞게 URL을 반환하는 함수를 정의했습니다 !

>### 유저의 로그인 상태를 반환하는 API 함수 정의 (870fc37aae2db1b1aaf5efb592047c9766f12099)

로그인이 유효하면 200, 유효하지 않으면 401 status 를 반환하는 API 함수를 작성했습니다 !

첫 화면에서 " 여운 시작하기 " 버튼을 눌렀을 때 **로그인이 유효하지 않다면 로그인 페이지로 이동, 로그인이 유효하다면 오늘의 질문 페이지로 이동** 하는 로직을 작성하면서 사용했습니다 ! (dc0229b39f1768bcff0822f1ad6ed80473e01db9)
