### PR TITLE
FEAT: 금지어 검증 규칙 수정사항 반영

### DIFF
--- a/backend/src/test/java/yeoun/question/service/ForbiddenWordServiceTest.java
+++ b/backend/src/test/java/yeoun/question/service/ForbiddenWordServiceTest.java
@@ -29,7 +29,7 @@ class ForbiddenWordServiceTest {
     @Test
     void validateForbiddenWord() {
         // given
-        String content = "당신은 좆같은 경험이 있나요?";
+        String content = "당신은 시발인 경험이 있나요?";
         ForbiddenWord word1 = new ForbiddenWord(1L, "시발");
         ForbiddenWord word2 = new ForbiddenWord(2L, "좆");
         List<ForbiddenWord> allWords = List.of(word1, word2);
@@ -41,7 +41,7 @@ class ForbiddenWordServiceTest {
                 .satisfies(e -> {
                     CustomException ex = (CustomException) e;
                     assertThat(ex.getMessage()).isEqualTo("질문 내용에 금지어가 포함되어 있습니다");
-                    assertThat(ex.getData()).isEqualTo(List.of("좆"));
+                    assertThat(ex.getData()).isEqualTo(List.of("시발"));
                 });
     }
 
@@ -59,6 +59,41 @@ class ForbiddenWordServiceTest {
 
         // when & then
         forbiddenWordService.validateForbiddenWord(content);
+    }
+
+    @DisplayName("금지어 사이에 4글자 이상인 경우 예외가 발생하지 않는다.")
+    @Test
+    void validateForbiddenWord_3orMoreLettersBetweenForbiddenWord_shouldNotThrowException() {
+        // given
+        List<ForbiddenWord> forbiddenWords = List.of(
+                new ForbiddenWord(1L, "시발"),
+                new ForbiddenWord(2L, "좆")
+        );
+        given(forbiddenWordRepository.findAll()).willReturn(forbiddenWords);
+
+        String content = "시&1@#발 짜증나네";
+
+        // when & then
+        forbiddenWordService.validateForbiddenWord(content);
+    }
+
+    @DisplayName("한글자 금지어가 단독으로 사용된 경우 CustomException을 던진다.")
+    @Test
+    void validateForbiddenWord_OneLettersForbiddenWord_shouldThrowException() {
+        // given
+        String content = "엿 먹어";
+        ForbiddenWord word1 = new ForbiddenWord(1L, "엿");
+        List<ForbiddenWord> allWords = List.of(word1);
+        given(forbiddenWordService.getAllForbiddenWords()).willReturn(allWords);
+
+        // when & then
+        assertThatThrownBy(() -> forbiddenWordService.validateForbiddenWord(content))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException ex = (CustomException) e;
+                    assertThat(ex.getMessage()).isEqualTo("질문 내용에 금지어가 포함되어 있습니다");
+                    assertThat(ex.getData()).isEqualTo(List.of("엿"));
+                });
     }
 
 }


### PR DESCRIPTION
- 금지어 사이 3글자까지 금지어로 판정되도록 수정
  > 씨@#1발 -> ❌
  > 씨123451발 -> ✅

- 금지어가 한글자인 경우 단독으로 사용시에만 금지어로 판정되도록 수정
  > 엿 같네 ->  ❌, 짜증나는 년 -> ❌
  > 엿장수 -> ✅, 2025년 -> ✅

- 금지어 반환 응답 시 전체 내용 포함하도록 수정
  > (기존) 씨11발 -> 씨발
  > (수정) 씨11발 -> 씨11발